### PR TITLE
Expect `shadow-cljs` to be found in path

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const pparams = process.argv.slice(2).join(' ')
 const currentPath = process.cwd();
 const spawn = require('child_process').spawn;
 const options = {cwd: currentPath, shell: process.env.SHELL};
-const shadow = require('child_process').spawn(`/usr/local/bin/shadow-cljs ${pparams}`, options);
+const shadow = require('child_process').spawn(`shadow-cljs ${pparams}`, options);
 
 const gray = '#eff0f1'
 


### PR DESCRIPTION
If we just call `shadow-cljs` we can assume that somehow the user has it in their path. That way it is more flexible when dealing with different systems and does not care if it was installed globally with `sudo` (as usual) or [without it](https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md). WDYT?

Thanks!  