### PR TITLE
Split parsing and notification

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,21 +40,18 @@ function parseData(data) {
 
 notifyUpdate('started')
 
-shadow.stdout.on('data', (data) => {
-  var status = parseData(data)
-  if (status) {
-    notifyUpdate(status)
-  }
-  console.log(`${data}`)
-})
 
-shadow.stderr.on('data', (data) => {
+function onData(data) {
   var status = parseData(data)
   if (status) {
     notifyUpdate(status)
   }
   console.log(`${data}`)
-})
+}
+
+shadow.stdout.on('data', onData)
+
+shadow.stderr.on('data', onData)
 
 shadow.on('close', (code) => {
   console.log(`child process exited with code ${code}`)


### PR DESCRIPTION
I think that this can be much powerful if we make it more flexible. By separating the data parsing and status update notifications, we make it possible for users to customize the notify functions to do whatever they want.

The next thing I'd like this to do is allowing a notification argument that could be an executable file which is called with the current status as a param and:
A) sets the tmux options it wants (unidirectional)
or
B) returns a list of params that `shadow-cljs-tmux` would use to make calls to `tmux` (bidirectional)

WDYT?

_Another thought about this: by overriding `parseData`, `notifyUpdate` and the actual process that it spawns, this can become a universal T, which just echoes the data it receives and notifies what it's able to parse._

Thanks!